### PR TITLE
Multiple spec changes - support for aka, controller, ; -> , & list of service endpoints

### DIFF
--- a/spec/registry/spec.md
+++ b/spec/registry/spec.md
@@ -7,7 +7,7 @@ The DID DHT Method Specification Registry 1.0
 
 **Draft Created:** November 20, 2023
 
-**Latest Update:** January 4, 2024
+**Latest Update:** January 5, 2024
 
 **Editors:**
 ~ [Gabe Cohen](https://github.com/decentralgabe)
@@ -45,7 +45,7 @@ record is as follows:
 
 | Name      | Type | TTL  | Rdata                                                     |
 | --------- | ---- | ---- | --------------------------------------------------------- |
-| _k0._did. | TXT  | 7200 | id=abcd,t=0,k=r96mnGNgWGOmjt6g_3_0nd4Kls5-kknrd4DdPW8qtfw |
+| _k0._did. | TXT  | 7200 | id=#abcd;t=0;k=r96mnGNgWGOmjt6g_3_0nd4Kls5-kknrd4DdPW8qtfw |
 
 ### Indexed Types
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -376,6 +376,10 @@ To create a `did:dht`, the process is as follows:
 4. Construct a signed [[ref:BEP44]] put message with the `v` value as a [[ref:bencode]]d DNS packet from the prior step.
 
 5. Submit the result of to the [[ref:DHT]] via a [[ref:Pkarr]] relay, or a [[ref:Gateway]], with the identifier created in step 1.
+
+::: note
+This specification **does not** make use of JSON-LD. As such it is prohibited to inclue an `@context` property in the DID Document.
+:::
  
 #### Read
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -203,6 +203,33 @@ An example of a _root record_ is as follows:
 
 The following instructions serve as a reference of mapping DID Document properties to [DNS TXT records](https://en.wikipedia.org/wiki/TXT_record):
 
+#### Identifiers
+
+##### Controller
+
+A [DID controller](https://www.w3.org/TR/did-core/#did-controller) ****MAY**** be present in a `did:dht` document. 
+
+If present, a DID controller ****MUST**** be represented as a `_cnt._did` record where the value is the controller's DID identifier.
+
+An example is given as follows:
+
+| Name       | Type | TTL  | Rdata            |
+| ---------- | ---- | ---- | ---------------- |
+| _cnt._did. | TXT  | 7200 | did:example:abcd |
+
+##### Also Known As
+
+A `did:dht` document ****MAY**** have multiple identifiers using the [alsoKnownAs](https://www.w3.org/TR/did-core/#also-known-as) property.
+
+If present, alternate DID identifiers ****MUST**** be represented as `_aka_.did` record as a list under the key `id=<ids>` where `ids`
+is a comma-separated list of DID identifiers.
+
+An example is given as follows:
+
+| Name       | Type | TTL  | Rdata                                  |
+| ---------- | ---- | ---- | -------------------------------------- |
+| _aka._did. | TXT  | 7200 | id=did:example:efgh,did:example:ijkl   |
+
 #### Verification Methods
 
 * Each Verification Method **name** is represented as a `_kN._did` record where `N` is the zero-indexed positional index of
@@ -259,33 +286,6 @@ An example is given as follows:
 
 Each Service is represented as part of the root `_did.TLD.` record as a list under the key `srv=<ids>` where `ids`
 is a comma-separated list of all IDs for each Service.
-
-#### Identifiers
-
-#### Controller
-
-A [DID controller](https://www.w3.org/TR/did-core/#did-controller) ****MAY**** be present in a `did:dht` document. 
-
-If present, a DID controller ****MUST**** be represented as a `_cnt._did` record where the value is the controller's DID identifier.
-
-An example is given as follows:
-
-| Name       | Type | TTL  | Rdata            |
-| ---------- | ---- | ---- | ---------------- |
-| _cnt._did. | TXT  | 7200 | did:example:abcd |
-
-#### Also Known As
-
-A `did:dht` document ****MAY**** have multiple identifiers using the [alsoKnownAs](https://www.w3.org/TR/did-core/#also-known-as) property.
-
-If present, alternate DID identifiers ****MUST**** be represented as `_aka_.did` record as a list under the key `id=<ids>` where `ids`
-is a comma-separated list of DID identifiers.
-
-An example is given as follows:
-
-| Name       | Type | TTL  | Rdata                                  |
-| ---------- | ---- | ---- | -------------------------------------- |
-| _aka._did. | TXT  | 7200 | id=did:example:efgh,did:example:ijkl |
 
 #### Example
 


### PR DESCRIPTION
Fix #79, #85, and more

* change , to ; (commas separate lists, ;'s separate elements) as per #79 
* add # as a WYSIWYG property for key ids and service ids
* support service endpoints being single value or array 
* support other properties in service endpoints in the same record
* add guidance on representing records for AKA and controller properties
* updated test vectors