### PR TITLE
chore: add quickstart shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,45 @@
 # did-dht-method
 
-The `did:dht` method. Home to the [DID DHT Method Specification](https://did-dht.com), and a reference implementation of a 
+The `did:dht` method. Home to the [DID DHT Method Specification](https://did-dht.com), and a reference implementation of a
 gateway server in Go.
 
 ## Build & Run
 
-To build and run the gateway server, from the `impl` directory run:
+### Quickstart
+
+To build and run in a single command `./scripts/quickstart.sh`.
 
 ```
-docker build --build-arg GIT_COMMIT_HASH=$(git rev-parse HEAD) . -t did-dht -f build/Dockerfile
+Usage: ./scripts/quickstart.sh [options]
+
+Builds and runs the did-dht server
+
+Options
+  -h, --help          show this help message and exit
+  -c, --commit=<hash> commit hash for `docker build` (default: HEAD)
+  -t, --tag=<tag>     tag name for `docker build` (default: did-dht:latest)
+  -a, --attach        run the container in the foreground (default: true)
+  -k, --keep          keep the container after it exits (default: false)
+  -n, --name=<name>   name to give the container (default: did-dht-server)
+  -p, --port=<port>   ports to publish the host/container (default: 8305:8305)
+  --skip-run          skip running the container (default: false)
+ ```
+
+### `docker`
+
+To build and run the gateway server, from the `impl` directory run:
+
+```sh
+docker build \
+  --build-arg GIT_COMMIT_HASH=$(git rev-parse head) \
+  --tag did-dht \
+  --file build/Dockerfile .
 ```
 
 and then
 
-```
-docker run -p8305:8305 did-dht
+```sh
+docker run --publish 8305:8305 did-dht
 ```
 
 ## Implementations

--- a/impl/README.md
+++ b/impl/README.md
@@ -26,16 +26,38 @@ How it works:
 
 ## Build & Run
 
-Run:
+### Quickstart
+
+To build and run in a single command `./scripts/quickstart.sh`.
 
 ```
-docker build --build-arg GIT_COMMIT_HASH=$(git rev-parse HEAD) . -t did-dht -f build/Dockerfile
+Usage: ./scripts/quickstart.sh [options]
+
+Builds and runs the did-dht server
+
+Options
+  -h, --help          show this help message and exit
+  -c, --commit=<hash> commit hash for `docker build` (default: HEAD)
+  -t, --tag=<tag>     tag name for `docker build` (default: did-dht:latest)
+  -a, --attach        run the container in the foreground (default: true)
+  -k, --keep          keep the container after it exits (default: false)
+  -n, --name=<name>   name to give the container (default: did-dht-server)
+  -p, --port=<port>   ports to publish the host/container (default: 8305:8305)
+  --skip-run          skip running the container (default: false)
+ ```
+
+### `docker`
+Run:
+
+```sh
+docker build \
+  --build-arg GIT_COMMIT_HASH=$(git rev-parse head) \
+  --tag did-dht \
+  --file build/Dockerfile .
 ```
 
 and then
 
+```sh
+docker run --publish 8305:8305 did-dht
 ```
-docker run -p8305:8305 did-dht
-```
-
-

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+_commands=(
+  "docker"
+  "git"
+)
+
+for cmd in "${_commands[@]}"; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "error: $cmd could not be found"
+    exit 1
+  fi
+done
+
+repo_path="$(git rev-parse --show-toplevel)"
+impl_path="$repo_path/impl"
+
+if ! pushd "$impl_path" > /dev/null; then
+  echo "error: unable to find '$impl_path'"
+  exit 1
+fi
+
+docker_path="$impl_path/build/Dockerfile"
+if [ ! -f "$docker_path" ]; then
+  echo "error: unable to find Dockerfile '$docker_path'"
+  exit 1
+fi
+
+# defaults ---------------------------------------------------------------------
+# docker build
+opt_commit_hash="$(git rev-parse HEAD)"
+opt_tag="did-dht:latest"
+
+# docker run
+opt_detach="--detach"
+opt_remove="--rm"
+opt_name="did-dht-server"
+opt_port="8305:8305"
+opt_skip_run="false"
+opt_erroneous_option="false"
+
+for opt in "$@"; do
+  case "$opt" in
+    -h | --help)
+      echo "Usage: $0 [options]"
+      echo ""
+      echo "Builds and runs the did-dht server"
+      echo ""
+      echo "Options"
+      echo "  -h, --help          show this help message and exit"
+      echo "  -c, --commit=<hash> commit hash for \`docker build\` (default: HEAD)"
+      echo "  -t, --tag=<tag>     tag name for \`docker build\` (default: did-dht:latest)"
+      echo "  -a, --attach        run the container in the foreground (default: true)"
+      echo "  -k, --keep          keep the container after it exits (default: false)"
+      echo "  -n, --name=<name>   name to give the container (default: did-dht-server)"
+      echo "  -p, --port=<port>   ports to publish the host/container (default: 8305:8305)"
+      echo "  --skip-run          skip running the container (default: false)"
+      exit 0
+      ;;
+
+    # build options ------------------------------------------------------------
+    -c=* | --commit=*)
+      opt_commit_hash="${opt#*=}"
+      shift
+      ;;
+
+    -t=* | --tag=*)
+      opt_tag="${opt#*=}"
+      shift
+      ;;
+
+    # run options --------------------------------------------------------------
+    -a | --attach)
+      unset opt_detach
+      shift
+      ;;
+
+    -k | --keep)
+      unset opt_remove
+      shift
+      ;;
+
+    -n=* | --name=*)
+      opt_name="${opt#*=}"
+      shift
+      ;;
+
+    -p=* | --port=*)
+      opt_port="${opt#*=}"
+      shift
+      ;;
+
+    --skip-run)
+      opt_skip_run="true"
+      shift
+      ;;
+
+    *)
+      echo "warn: skipping unknown option '$1'"
+      opt_erroneous_option="true"
+      shift
+      ;;
+  esac
+done
+
+if [ "$opt_erroneous_option" == "true" ]; then
+  echo ""
+  echo "warning: one or more options were skipped"
+  echo "         run \`$0 --help\` for more information"
+  echo ""
+  exit 1
+fi
+
+if git cat-file -e "$opt_commit_hash"; then
+  echo "info: building from commit $opt_commit_hash"
+else
+  echo "error: commit $opt_commit_hash does not exist"
+  exit 1
+fi
+
+DEBUG_FLAG="false"
+if [ "$DEBUG_FLAG" == "true" ]; then
+  echo "info: running in debug mode"
+  _DEBUG="echo"
+else
+  unset _DEBUG
+fi
+
+echo "created image $opt_tag at commit ${opt_commit_hash:0:8}"
+$_DEBUG docker build \
+  --build-arg GIT_COMMIT_HASH="$opt_commit_hash" \
+  --tag "$opt_tag" \
+  --file "$docker_path" \
+  "$impl_path"
+
+echo ""
+if [ "$opt_skip_run" == "true" ]; then
+  echo "info: skipping run"
+  exit 0
+fi
+
+if docker ps --all --format '{{.Names}}' | grep --quiet "$opt_name"; then
+  echo "error: container $opt_name already exists"
+  exit 1
+fi
+
+printf "info: running container: "
+$_DEBUG docker run \
+  "$opt_detach" \
+  "$opt_remove" \
+  --interactive \
+  --tty \
+  --publish "$opt_port" \
+  --name "$opt_name" \
+  "$opt_tag"


### PR DESCRIPTION
Added a `quickstart.sh` script to add some sensible defaults to `docker` so it's cleaned up upon shutdown and so it can be used across a variety of shell environments. It's nothing fancy but runs both `build` and `run` in a single command with the most common configurations.

**Context**: The default run command includes `GIT_COMMIT_HASH` which uses `$(...)`, which isn't included in the `fish` shell by design. Instead of adding separate steps for `fish` and `bash`/`zsh`, we provide a `quickstart.sh` that can be run from anywhere within the repo.

**Options**: Almost all of the defaults should remain unchanged, but added some additional flags to make it easier to work with. The original `README.md` retains the default commands but with `--long-opts` for self-documenting options.

Namely these options:
 * `--commit (default: HEAD)` to verify the correct hash before building
 * `--attach (default: false)` so it can run in the background by 
   * `--interactive` and `--tty` enables to use `docker attach <container_id>` but use `ctrl-p, ctrl-q` to suspend without exiting
 * `--name (default: did-dht-server)` to avoid `docker` generated names
 * `--keep` (default: container removed) to keep the container around
 * `--port (default: 8305:8305)` to specify the port

Additionally, we added some guard clauses to streamline the development experience.

# Sample output
```
$ ../scripts/quickstart.sh
info: building from commit 86a86fc4ad8c1a5650eee0424f525c910dabd923
created image did-dht:latest at commit 86a86fc4
[+] Building 0.8s (12/12) FINISHED                                                                                                       docker:desktop-linux
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 555B                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/golang:1.21.5-alpine                                                                                  0.7s
 => [1/7] FROM docker.io/library/golang:1.21.5-alpine@sha256:4db4aac30880b978cae5445dd4a706215249ad4f43d28bd7cdf7906e9be8dd6b                            0.0s
 => [internal] load build context                                                                                                                        0.0s
 => => transferring context: 2.56kB                                                                                                                      0.0s
 => CACHED [2/7] WORKDIR /app                                                                                                                            0.0s
 => CACHED [3/7] COPY go.mod ./                                                                                                                          0.0s
 => CACHED [4/7] COPY go.sum ./                                                                                                                          0.0s
 => CACHED [5/7] RUN go mod download                                                                                                                     0.0s
 => CACHED [6/7] COPY . ./                                                                                                                               0.0s
 => CACHED [7/7] RUN go build -ldflags="-X main.commitHash=86a86fc4ad8c1a5650eee0424f525c910dabd923" -tags jwx_es256k -o /did-dht ./cmd                  0.0s
 => exporting to image                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                  0.0s
 => => writing image sha256:6eaa5ddc8726fa74c503f46a5d1d9e2cc450a402578717f51fb781ff7297fb6f                                                             0.0s
 => => naming to docker.io/library/did-dht:latest                                                                                                        0.0s

What's Next?
  1. Sign in to your Docker account → docker login
  2. View a summary of image vulnerabilities and recommendations → docker scout quickview
 
info: running container: b16354cbd38f82b95739683f8d9c50be800d57ef8f7d517b544a75732e3aad27
```
