### PR TITLE
chore: set quickstart.sh to attach by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Options
   -h, --help          show this help message and exit
   -c, --commit=<hash> commit hash for `docker build` (default: HEAD)
   -t, --tag=<tag>     tag name for `docker build` (default: did-dht:latest)
-  -a, --attach        run the container in the foreground (default: true)
+  -d, --detach        run the container in the background (default: false)
   -k, --keep          keep the container after it exits (default: false)
   -n, --name=<name>   name to give the container (default: did-dht-server)
   -p, --port=<port>   ports to publish the host/container (default: 8305:8305)

--- a/impl/README.md
+++ b/impl/README.md
@@ -39,7 +39,7 @@ Options
   -h, --help          show this help message and exit
   -c, --commit=<hash> commit hash for `docker build` (default: HEAD)
   -t, --tag=<tag>     tag name for `docker build` (default: did-dht:latest)
-  -a, --attach        run the container in the foreground (default: true)
+  -d, --detach        run the container in the background (default: false)
   -k, --keep          keep the container after it exits (default: false)
   -n, --name=<name>   name to give the container (default: did-dht-server)
   -p, --port=<port>   ports to publish the host/container (default: 8305:8305)


### PR DESCRIPTION
Defaulting to attach (i.e. foreground) to maintain the original intent. Added some a reminder control sequence to send it to the background `--detach`) for users that might not remember `docker`.

```
info: building from commit 2851f13560a33ece048f8bc728baa7d8c7de6c95
created image did-dht:latest at commit 2851f135
[+] Building 13.2s (12/12) FINISHED                                                                                                                                                                    

... removed for brevity ...

What's Next?
  1. Sign in to your Docker account → docker login
  2. View a summary of image vulnerabilities and recommendations → docker scout quickview

info: running in foreground
info: use ctrl-p ctrl-q to detach from the container (send to background)
INFO[0000] Starting up...
INFO[0000] With commit: 2851f13560a33ece048f8bc728baa7d8c7de6c95
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
```