### PR TITLE
Add logging configuration options and other misc logging improvements

### DIFF
--- a/impl/config/config.go
+++ b/impl/config/config.go
@@ -37,6 +37,7 @@ func (e EnvironmentVariable) String() string {
 }
 
 type Config struct {
+	Log          LogConfig          `toml:"log"`
 	ServerConfig ServerConfig       `toml:"server"`
 	DHTConfig    DHTServiceConfig   `toml:"dht"`
 	PkarrConfig  PKARRServiceConfig `toml:"pkarr"`
@@ -48,7 +49,6 @@ type ServerConfig struct {
 	APIPort     int         `toml:"api_port"`
 	BaseURL     string      `toml:"base_url"`
 	LogLocation string      `toml:"log_location"`
-	LogLevel    string      `toml:"log_level"`
 	StorageURI  string      `toml:"storage_uri"`
 }
 
@@ -62,6 +62,11 @@ type PKARRServiceConfig struct {
 	CacheSizeLimitMB int    `toml:"cache_size_limit_mb"`
 }
 
+type LogConfig struct {
+	Level string `toml:"level"`
+	Path  string `toml:"path"`
+}
+
 func GetDefaultConfig() Config {
 	return Config{
 		ServerConfig: ServerConfig{
@@ -70,7 +75,6 @@ func GetDefaultConfig() Config {
 			APIPort:     8305,
 			BaseURL:     "http://localhost:8305",
 			LogLocation: "log",
-			LogLevel:    "debug",
 			StorageURI:  "bolt://diddht.db",
 		},
 		DHTConfig: DHTServiceConfig{
@@ -80,6 +84,9 @@ func GetDefaultConfig() Config {
 			RepublishCRON:    "0 */2 * * *",
 			CacheTTLSeconds:  600,
 			CacheSizeLimitMB: 500,
+		},
+		Log: LogConfig{
+			Level: logrus.InfoLevel.String(),
 		},
 	}
 }

--- a/impl/go.mod
+++ b/impl/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
+	github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f
 	github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa
 	go.etcd.io/bbolt v1.3.7
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.46.1

--- a/impl/go.sum
+++ b/impl/go.sum
@@ -606,6 +606,8 @@ github.com/swaggo/swag v1.8.12/go.mod h1:lNfm6Gg+oAq3zRJQNEMBE66LIJKM44mxFqhEEgy
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f h1:oqdnd6OGlOUu1InG37hWcCB3a+Jy3fwjylyVboaNMwY=
+github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f/go.mod h1:X3Dd1SB8Gt1V968NTzpKFjMM6O8ccta2NPC6MprOxZQ=
 github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa h1:2EwhXkNkeMjX9iFYGWLPQLPhw9O58BhnYgtYKeqybcY=
 github.com/tv42/zbase32 v0.0.0-20220222190657-f76a9fc892fa/go.mod h1:is48sjgBanWcA5CQrPBu9Y5yABY/T2awj/zI65bq704=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=


### PR DESCRIPTION
gin access logs now use logrus, and generally don't output non-JSON in prod environments

Fixes #40

Sample output for env = prod

```json
{
  "file": "/Users/fherzfeld/src/github.com/TBD54566975/did-dht-method/impl/cmd/main.go:43",
  "func": "main.main",
  "level": "info",
  "msg": "starting up",
  "time": "2024-01-23T13:15:41-08:00"
}
{
  "file": "/Users/finn/src/github.com/TBD54566975/did-dht-method/impl/cmd/main.go:58",
  "func": "main.run",
  "level": "info",
  "msg": "loading config from file",
  "path": "config/config.toml",
  "time": "2024-01-23T13:15:41-08:00"
}
{
  "environment": "prod",
  "file": "/Users/finn/src/github.com/TBD54566975/did-dht-method/impl/pkg/server/server.go:84",
  "func": "github.com/TBD54566975/did-dht-method/pkg/server.setupHandler",
  "level": "info",
  "msg": "configuring server for environment",
  "time": "2024-01-23T13:15:41-08:00"
}
{
  "file": "/Users/finn/src/github.com/TBD54566975/did-dht-method/impl/cmd/main.go:87",
  "func": "main.run.func2",
  "level": "info",
  "listen_address": "0.0.0.0:8305",
  "msg": "starting listener",
  "time": "2024-01-23T13:15:41-08:00"
}
{
  "clientIP": "::1",
  "dataLength": 16,
  "file": "/Users/finn/go/pkg/mod/github.com/toorop/gin-logrus@v0.0.0-20210225092905-2c785434f26f/logger.go:80",
  "func": "github.com/toorop/gin-logrus.Logger.func1",
  "hostname": "finn-mac.local",
  "latency": 1,
  "level": "info",
  "method": "GET",
  "msg": "::1 - finn-mac.local [23/Jan/2024:13:15:44 -0800] \"GET /health\" 200 16 \"\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\" (1ms)",
  "path": "/health",
  "referer": "",
  "statusCode": 200,
  "time": "2024-01-23T13:15:44-08:00",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
}
{
  "file": "/Users/finn/src/github.com/TBD54566975/did-dht-method/impl/cmd/main.go:95",
  "func": "main.run",
  "level": "info",
  "msg": "shutdown signal received",
  "signal": "interrupt",
  "time": "2024-01-23T13:15:46-08:00"
}
```