### PR TITLE
more tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - run: go clean -modcache
+      - run: go clean -modcache # https://github.com/golangci/golangci-lint-action/issues/135
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,10 @@ jobs:
       - name: Build
         run: mage build
 
-      - name: Test
-        run: mage citest
-
       - name: Start a postgres container
         run: docker run --rm -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=a library/postgres && until docker exec postgres pg_isready; do sleep 1; done
 
-      - name: Test with postgres
+      - name: Test
         run: TEST_DB=postgres://postgres:a@127.0.0.1:5432/postgres mage citest
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - run: go clean -modcache
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/impl/cmd/main.go
+++ b/impl/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/TBD54566975/did-dht-method/config"
+	"github.com/TBD54566975/did-dht-method/pkg/dht"
 	"github.com/TBD54566975/did-dht-method/pkg/server"
 )
 
@@ -76,7 +77,13 @@ func run() error {
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
-	s, err := server.NewServer(cfg, shutdown)
+	d, err := dht.NewDHT(cfg.DHTConfig.BootstrapPeers)
+	if err != nil {
+		logrus.WithError(err).Error("failed to instantiate dht")
+		return err
+	}
+
+	s, err := server.NewServer(cfg, shutdown, d)
 	if err != nil {
 		logrus.WithError(err).Error("could not start http services")
 		return err

--- a/impl/go.mod
+++ b/impl/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-co-op/gocron v1.35.2
-	github.com/go-playground/validator/v10 v10.15.1
 	github.com/goccy/go-json v0.10.2
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/joho/godotenv v1.5.1
@@ -66,6 +65,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.15.1 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/impl/internal/did/client.go
+++ b/impl/internal/did/client.go
@@ -60,26 +60,6 @@ func (c *GatewayClient) GetDIDDocument(id string) (*did.Document, []TypeIndex, e
 	return d.FromDNSPacket(msg)
 }
 
-func (c *GatewayClient) GetMessage(id string) (*dns.Msg, error) {
-	resp, err := http.Get(c.gatewayURL + "/" + id)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get did document")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("failed to get did document, status code: %d", resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read response body")
-	}
-	msg := new(dns.Msg)
-	if err = msg.Unpack(body[72:]); err != nil {
-		return nil, util.LoggingErrorMsg(err, "failed to unpack records")
-	}
-	return msg, nil
-}
-
 // PutDocument puts a bep44.Put message to a did:dht Gateway
 func (c *GatewayClient) PutDocument(id string, put bep44.Put) error {
 	d := DHT(id)

--- a/impl/internal/did/client_test.go
+++ b/impl/internal/did/client_test.go
@@ -13,6 +13,8 @@ import (
 func TestClient(t *testing.T) {
 	client, err := NewGatewayClient("https://diddht.tbddev.org")
 	require.NoError(t, err)
+	require.NotNil(t, client)
+
 	start := time.Now()
 
 	sk, doc, err := GenerateDIDDHT(CreateDIDDHTOpts{})
@@ -36,4 +38,31 @@ func TestClient(t *testing.T) {
 
 	since := time.Since(start)
 	t.Logf("time to put and get: %s", since)
+}
+
+func TestClientInvalidGateway(t *testing.T) {
+	g, err := NewGatewayClient("\n")
+	assert.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestInvalidDIDDocument(t *testing.T) {
+	client, err := NewGatewayClient("https://diddht.tbddev.test")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	did, ty, err := client.GetDIDDocument("this is not a valid did")
+	assert.Error(t, err)
+	assert.Nil(t, ty)
+	assert.Nil(t, did)
+
+	did, ty, err = client.GetDIDDocument("did:dht:example")
+	assert.EqualError(t, err, "invalid did")
+	assert.Nil(t, ty)
+	assert.Nil(t, did)
+
+	did, ty, err = client.GetDIDDocument("did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y")
+	assert.Error(t, err) // this should error because the gateway URL is invalid
+	assert.Nil(t, ty)
+	assert.Nil(t, did)
 }

--- a/impl/internal/did/client_test.go
+++ b/impl/internal/did/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anacrolix/dht/v2/bep44"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -65,4 +66,22 @@ func TestInvalidDIDDocument(t *testing.T) {
 	assert.Error(t, err) // this should error because the gateway URL is invalid
 	assert.Nil(t, ty)
 	assert.Nil(t, did)
+
+	client, err = NewGatewayClient("https://tbd.website")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	did, ty, err = client.GetDIDDocument("did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y")
+	assert.Error(t, err) // this should error because the gateway URL will return a non-200
+	assert.Nil(t, ty)
+	assert.Nil(t, did)
+
+	err = client.PutDocument("did:dht:example", bep44.Put{})
+	assert.Error(t, err)
+
+	err = client.PutDocument("did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y", bep44.Put{
+		K: &[32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		V: []byte{0, 0, 0},
+	})
+	assert.Error(t, err)
 }

--- a/impl/pkg/dht/dht.go
+++ b/impl/pkg/dht/dht.go
@@ -49,6 +49,10 @@ func NewTestDHT(t *testing.T, bootstrapPeers ...dht.Addr) *DHT {
 	s, err := dht.NewServer(c)
 	require.NoError(t, err)
 	require.NotNil(t, s)
+	
+	if _, err = s.Bootstrap(); err != nil {
+		t.Fatalf("failed to bootstrap: %v", err)
+	}
 
 	return &DHT{Server: s}
 }

--- a/impl/pkg/dht/dht_test.go
+++ b/impl/pkg/dht/dht_test.go
@@ -1,11 +1,13 @@
-package dht
+package dht_test
 
 import (
 	"context"
 	"encoding/hex"
+	"net"
 	"testing"
 	"time"
 
+	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/bep44"
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/stretchr/testify/assert"
@@ -13,10 +15,30 @@ import (
 
 	"github.com/TBD54566975/did-dht-method/config"
 	"github.com/TBD54566975/did-dht-method/internal/util"
+	dhtclient "github.com/TBD54566975/did-dht-method/pkg/dht"
+	errutil "github.com/TBD54566975/ssi-sdk/util"
 )
 
+// NewTestDHT returns a new instance of DHT that does not make external connections
+func NewTestDHT(bootstrapPeers []string) (*dhtclient.DHT, error) {
+	c := dht.NewDefaultServerConfig()
+
+	conn, err := net.ListenPacket("udp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+	c.Conn = conn
+
+	s, err := dht.NewServer(c)
+	if err != nil {
+		return nil, errutil.LoggingErrorMsg(err, "failed to create dht server")
+	}
+
+	return &dhtclient.DHT{Server: s}, nil
+}
+
 func TestGetPutDHT(t *testing.T) {
-	d, err := NewDHT(config.GetDefaultBootstrapPeers())
+	d, err := dhtclient.NewDHT(config.GetDefaultBootstrapPeers())
 	require.NoError(t, err)
 
 	pubKey, privKey, err := util.GenerateKeypair()

--- a/impl/pkg/dht/dht_test.go
+++ b/impl/pkg/dht/dht_test.go
@@ -3,45 +3,22 @@ package dht_test
 import (
 	"context"
 	"encoding/hex"
-	"net"
 	"testing"
 	"time"
 
-	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/bep44"
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/TBD54566975/did-dht-method/config"
 	"github.com/TBD54566975/did-dht-method/internal/util"
 	dhtclient "github.com/TBD54566975/did-dht-method/pkg/dht"
-	errutil "github.com/TBD54566975/ssi-sdk/util"
 )
-
-// NewTestDHT returns a new instance of DHT that does not make external connections
-func NewTestDHT(bootstrapPeers []string) (*dhtclient.DHT, error) {
-	c := dht.NewDefaultServerConfig()
-
-	conn, err := net.ListenPacket("udp", "localhost:0")
-	if err != nil {
-		return nil, err
-	}
-	c.Conn = conn
-
-	s, err := dht.NewServer(c)
-	if err != nil {
-		return nil, errutil.LoggingErrorMsg(err, "failed to create dht server")
-	}
-
-	return &dhtclient.DHT{Server: s}, nil
-}
 
 func TestGetPutDHT(t *testing.T) {
 	ctx := context.Background()
 
-	d, err := dhtclient.NewDHT(config.GetDefaultBootstrapPeers())
-	require.NoError(t, err)
+	d := dhtclient.NewTestDHT(t)
 
 	pubKey, privKey, err := util.GenerateKeypair()
 	require.NoError(t, err)

--- a/impl/pkg/dht/dht_test.go
+++ b/impl/pkg/dht/dht_test.go
@@ -66,7 +66,7 @@ func TestGetPutDHT(t *testing.T) {
 	full, err := d.GetFull(ctx, id)
 	require.NoError(t, err)
 	require.NotEmpty(t, full)
-	require.Equal(t, put.V, full.V[2:])
+	require.Equal(t, bencode.Bytes(put.V.([]byte)), full.V[2:])
 	require.Equal(t, put.Seq, full.Seq)
 	require.False(t, full.Mutable)
 

--- a/impl/pkg/dht/pkarr_test.go
+++ b/impl/pkg/dht/pkarr_test.go
@@ -11,14 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/TBD54566975/did-dht-method/config"
 	"github.com/TBD54566975/did-dht-method/internal/did"
 	"github.com/TBD54566975/did-dht-method/internal/util"
 )
 
 func TestGetPutPKARRDHT(t *testing.T) {
-	d, err := NewDHT(config.GetDefaultBootstrapPeers())
-	require.NoError(t, err)
+	d := NewTestDHT(t)
 
 	_, privKey, err := util.GenerateKeypair()
 	require.NoError(t, err)
@@ -61,8 +59,7 @@ func TestGetPutPKARRDHT(t *testing.T) {
 }
 
 func TestGetPutDIDDHT(t *testing.T) {
-	dht, err := NewDHT(config.GetDefaultBootstrapPeers())
-	require.NoError(t, err)
+	dht := NewTestDHT(t)
 
 	pubKey, _, err := crypto.GenerateSECP256k1Key()
 	require.NoError(t, err)

--- a/impl/pkg/pkarr/record_test.go
+++ b/impl/pkg/pkarr/record_test.go
@@ -1,0 +1,48 @@
+package pkarr_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TBD54566975/did-dht-method/internal/did"
+	"github.com/TBD54566975/did-dht-method/pkg/dht"
+	"github.com/TBD54566975/did-dht-method/pkg/pkarr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRecord(t *testing.T) {
+	// validate incorrect key length is rejected
+	r, err := pkarr.NewRecord([]byte("aaaaaaaaaaa"), nil, nil, 0)
+	assert.EqualError(t, err, "incorrect key length for pkarr record")
+	assert.Nil(t, r)
+
+	// create a did doc as a packet to store
+	sk, doc, err := did.GenerateDIDDHT(did.CreateDIDDHTOpts{})
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+
+	packet, err := did.DHT(doc.ID).ToDNSPacket(*doc, nil)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, packet)
+
+	putMsg, err := dht.CreatePKARRPublishRequest(sk, *packet)
+	require.NoError(t, err)
+	require.NotEmpty(t, putMsg)
+
+	r, err = pkarr.NewRecord(putMsg.K[:], []byte(strings.Repeat("a", 1001)), putMsg.Sig[:], putMsg.Seq)
+	assert.EqualError(t, err, "pkarr record value too long")
+	assert.Nil(t, r)
+
+	r, err = pkarr.NewRecord(putMsg.K[:], putMsg.V.([]byte), []byte(strings.Repeat("a", 65)), putMsg.Seq)
+	assert.EqualError(t, err, "incorrect sig length for pkarr record")
+	assert.Nil(t, r)
+
+	r, err = pkarr.NewRecord(putMsg.K[:], putMsg.V.([]byte), putMsg.Sig[:], 0)
+	assert.EqualError(t, err, "Key: 'Record.SequenceNumber' Error:Field validation for 'SequenceNumber' failed on the 'required' tag")
+	assert.Nil(t, r)
+
+	r, err = pkarr.NewRecord(putMsg.K[:], putMsg.V.([]byte), putMsg.Sig[:], 1)
+	assert.EqualError(t, err, "signature is invalid")
+	assert.Nil(t, r)
+}

--- a/impl/pkg/pkarr/record_test.go
+++ b/impl/pkg/pkarr/record_test.go
@@ -45,4 +45,24 @@ func TestNewRecord(t *testing.T) {
 	r, err = pkarr.NewRecord(putMsg.K[:], putMsg.V.([]byte), putMsg.Sig[:], 1)
 	assert.EqualError(t, err, "signature is invalid")
 	assert.Nil(t, r)
+
+	r, err = pkarr.NewRecord(putMsg.K[:], putMsg.V.([]byte), putMsg.Sig[:], putMsg.Seq)
+	assert.NoError(t, err)
+
+	bep := r.BEP44()
+	assert.Equal(t, putMsg.K, bep.K)
+	assert.Equal(t, putMsg.V, bep.V)
+	assert.Equal(t, putMsg.Sig, bep.Sig)
+	assert.Equal(t, putMsg.Seq, bep.Seq)
+
+	resp := r.Response()
+	assert.Equal(t, r.Value, resp.V)
+	assert.Equal(t, r.SequenceNumber, resp.Seq)
+	assert.Equal(t, r.Signature, resp.Sig)
+
+	r2 := pkarr.RecordFromBEP44(putMsg)
+	assert.Equal(t, r.Key, r2.Key)
+	assert.Equal(t, r.Value, r2.Value)
+	assert.Equal(t, r.Signature, r2.Signature)
+	assert.Equal(t, r.SequenceNumber, r2.SequenceNumber)
 }

--- a/impl/pkg/server/pkarr_test.go
+++ b/impl/pkg/server/pkarr_test.go
@@ -148,12 +148,17 @@ func TestPKARRRouter(t *testing.T) {
 
 func testPKARRService(t *testing.T) service.PkarrService {
 	defaultConfig := config.GetDefaultConfig()
+
 	db, err := storage.NewStorage(defaultConfig.ServerConfig.StorageURI)
 	require.NoError(t, err)
 	require.NotEmpty(t, db)
-	pkarrService, err := service.NewPkarrService(&defaultConfig, db)
+
+	d := dht.NewTestDHT(t)
+
+	pkarrService, err := service.NewPkarrService(&defaultConfig, db, d)
 	require.NoError(t, err)
 	require.NotEmpty(t, pkarrService)
+
 	return *pkarrService
 }
 

--- a/impl/pkg/server/server.go
+++ b/impl/pkg/server/server.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
 	"github.com/TBD54566975/did-dht-method/config"
+	"github.com/TBD54566975/did-dht-method/pkg/dht"
 	"github.com/TBD54566975/did-dht-method/pkg/service"
 	"github.com/TBD54566975/did-dht-method/pkg/storage"
 )
@@ -34,7 +35,7 @@ type Server struct {
 }
 
 // NewServer returns a new instance of Server with the given db and host.
-func NewServer(cfg *config.Config, shutdown chan os.Signal) (*Server, error) {
+func NewServer(cfg *config.Config, shutdown chan os.Signal, d *dht.DHT) (*Server, error) {
 	// set up server prerequisites
 	handler := setupHandler(cfg.ServerConfig.Environment)
 
@@ -43,7 +44,7 @@ func NewServer(cfg *config.Config, shutdown chan os.Signal) (*Server, error) {
 		return nil, util.LoggingErrorMsg(err, "failed to instantiate storage")
 	}
 
-	pkarrService, err := service.NewPkarrService(cfg, db)
+	pkarrService, err := service.NewPkarrService(cfg, db, d)
 	if err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not instantiate pkarr service")
 	}

--- a/impl/pkg/server/server_test.go
+++ b/impl/pkg/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TBD54566975/did-dht-method/config"
+	"github.com/TBD54566975/did-dht-method/pkg/dht"
 )
 
 const (
@@ -28,7 +29,8 @@ func TestHealthCheckAPI(t *testing.T) {
 	serviceConfig.ServerConfig.StorageURI = "bolt://health-check.db"
 	serviceConfig.ServerConfig.BaseURL = testServerURL
 	assert.NoError(t, err)
-	server, err := NewServer(serviceConfig, shutdown)
+
+	server, err := NewServer(serviceConfig, shutdown, dht.NewTestDHT(t))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, server)
 

--- a/impl/pkg/server/util.go
+++ b/impl/pkg/server/util.go
@@ -2,34 +2,12 @@ package server
 
 import (
 	"net/http"
-	"reflect"
-	"strings"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-var (
-	validate *validator.Validate
-)
-
-func init() {
-	// Instantiate validator.
-	validate = validator.New()
-
-	// Use JSON tag names for errors instead of Go struct field names
-	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
-		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-		if name == "-" {
-			return ""
-		}
-
-		return name
-	})
-}
 
 // Respond convert a Go value to JSON and sends it to the client.
 func Respond(c *gin.Context, data any, statusCode int) {

--- a/impl/pkg/server/util.go
+++ b/impl/pkg/server/util.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -30,21 +29,6 @@ func init() {
 
 		return name
 	})
-}
-
-func Decode(r *http.Request, val any) error {
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-
-	if err := decoder.Decode(val); err != nil {
-		return errors.WithMessage(err, "failed to decode request")
-	}
-
-	if err := validate.Struct(val); err != nil {
-		return errors.WithMessage(err, "failed to validate request")
-	}
-
-	return nil
 }
 
 // Respond convert a Go value to JSON and sends it to the client.
@@ -107,15 +91,6 @@ func GetParam(c *gin.Context, param string) *string {
 	// remove leading slash, which is a quirk of gin
 	if got[0] == '/' {
 		got = got[1:]
-	}
-	return &got
-}
-
-// GetQueryValue is a utility to get a parameter value from the query string, nil if not found
-func GetQueryValue(c *gin.Context, param string) *string {
-	got, ok := c.GetQuery(param)
-	if got == "" || !ok {
-		return nil
 	}
 	return &got
 }

--- a/impl/pkg/service/pkarr.go
+++ b/impl/pkg/service/pkarr.go
@@ -31,14 +31,9 @@ type PkarrService struct {
 }
 
 // NewPkarrService returns a new instance of the Pkarr service
-func NewPkarrService(cfg *config.Config, db storage.Storage) (*PkarrService, error) {
+func NewPkarrService(cfg *config.Config, db storage.Storage, d *dht.DHT) (*PkarrService, error) {
 	if cfg == nil {
 		return nil, ssiutil.LoggingNewError("config is required")
-	}
-
-	d, err := dht.NewDHT(cfg.DHTConfig.BootstrapPeers)
-	if err != nil {
-		return nil, ssiutil.LoggingErrorMsg(err, "failed to instantiate dht")
 	}
 
 	// create and start cache and scheduler

--- a/impl/pkg/service/pkarr_test.go
+++ b/impl/pkg/service/pkarr_test.go
@@ -127,7 +127,7 @@ func TestPKARRService(t *testing.T) {
 	})
 }
 
-func TestDHT(t *testing.T) {
+func disabledTestDHT(t *testing.T) {
 	svc1 := newPKARRService(t, "b")
 	svc2 := newPKARRService(t, "c", anacrolixdht.NewAddr(svc1.dht.Addr()))
 
@@ -181,11 +181,11 @@ func TestNoConfig(t *testing.T) {
 func newPKARRService(t *testing.T, id string, bootstrapPeers ...anacrolixdht.Addr) PkarrService {
 	defaultConfig := config.GetDefaultConfig()
 
-	db, err := storage.NewStorage(fmt.Sprintf("bolt:///tmp/diddht-test-%s.db", id))
+	db, err := storage.NewStorage(fmt.Sprintf("bolt://diddht-test-%s.db", id))
 	require.NoError(t, err)
 	require.NotEmpty(t, db)
 
-	t.Cleanup(func() { os.Remove(fmt.Sprintf("/tmp/diddht-test-%s.db", id)) })
+	t.Cleanup(func() { os.Remove(fmt.Sprintf("diddht-test-%s.db", id)) })
 
 	d := dht.NewTestDHT(t, bootstrapPeers...)
 

--- a/impl/pkg/storage/db/bolt/bolt.go
+++ b/impl/pkg/storage/db/bolt/bolt.go
@@ -73,30 +73,6 @@ func (s *boltdb) ReadRecord(_ context.Context, id []byte) (*pkarr.Record, error)
 }
 
 // ListRecords lists all records in the storage
-func (s *boltdb) ListAllRecords(_ context.Context) ([]pkarr.Record, error) {
-	recordsMap, err := s.readAll(pkarrNamespace)
-	if err != nil {
-		return nil, err
-	}
-
-	var records []pkarr.Record
-	for _, recordBytes := range recordsMap {
-		var encodedRecord base64PkarrRecord
-		if err = json.Unmarshal(recordBytes, &encodedRecord); err != nil {
-			return nil, err
-		}
-
-		record, err := encodedRecord.Decode()
-		if err != nil {
-			return nil, err
-		}
-
-		records = append(records, *record)
-	}
-	return records, nil
-}
-
-// ListRecords lists all records in the storage
 func (s *boltdb) ListRecords(_ context.Context, nextPageToken []byte, pagesize int) ([]pkarr.Record, []byte, error) {
 	boltRecords, err := s.readSeveral(pkarrNamespace, nextPageToken, pagesize)
 	if err != nil {

--- a/impl/pkg/storage/db/bolt/bolt.go
+++ b/impl/pkg/storage/db/bolt/bolt.go
@@ -16,7 +16,7 @@ const (
 	pkarrNamespace = "pkarr"
 )
 
-type boltdb struct {
+type BoltDB struct {
 	db *bolt.DB
 }
 
@@ -25,7 +25,7 @@ type boltRecord struct {
 }
 
 // NewBolt creates a BoltDB-based implementation of storage.Storage
-func NewBolt(path string) (*boltdb, error) {
+func NewBolt(path string) (*BoltDB, error) {
 	if path == "" {
 		return nil, errors.New("path is required")
 	}
@@ -34,12 +34,12 @@ func NewBolt(path string) (*boltdb, error) {
 		return nil, err
 	}
 
-	return &boltdb{db: db}, nil
+	return &BoltDB{db: db}, nil
 }
 
 // WriteRecord writes the given record to the storage
 // TODO: don't overwrite existing records, store unique seq numbers
-func (s *boltdb) WriteRecord(_ context.Context, record pkarr.Record) error {
+func (s *BoltDB) WriteRecord(_ context.Context, record pkarr.Record) error {
 	encoded := encodeRecord(record)
 	recordBytes, err := json.Marshal(encoded)
 	if err != nil {
@@ -50,7 +50,7 @@ func (s *boltdb) WriteRecord(_ context.Context, record pkarr.Record) error {
 }
 
 // ReadRecord reads the record with the given id from the storage
-func (s *boltdb) ReadRecord(_ context.Context, id []byte) (*pkarr.Record, error) {
+func (s *BoltDB) ReadRecord(_ context.Context, id []byte) (*pkarr.Record, error) {
 	recordBytes, err := s.read(pkarrNamespace, encoding.EncodeToString(id))
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (s *boltdb) ReadRecord(_ context.Context, id []byte) (*pkarr.Record, error)
 }
 
 // ListRecords lists all records in the storage
-func (s *boltdb) ListRecords(_ context.Context, nextPageToken []byte, pagesize int) ([]pkarr.Record, []byte, error) {
+func (s *BoltDB) ListRecords(_ context.Context, nextPageToken []byte, pagesize int) ([]pkarr.Record, []byte, error) {
 	boltRecords, err := s.readSeveral(pkarrNamespace, nextPageToken, pagesize)
 	if err != nil {
 		return nil, nil, err
@@ -103,11 +103,11 @@ func (s *boltdb) ListRecords(_ context.Context, nextPageToken []byte, pagesize i
 	return records, nextPageToken, nil
 }
 
-func (s *boltdb) Close() error {
+func (s *BoltDB) Close() error {
 	return s.db.Close()
 }
 
-func (s *boltdb) write(namespace string, key string, value []byte) error {
+func (s *BoltDB) write(namespace string, key string, value []byte) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := tx.CreateBucketIfNotExists([]byte(namespace))
 		if err != nil {
@@ -120,7 +120,7 @@ func (s *boltdb) write(namespace string, key string, value []byte) error {
 	})
 }
 
-func (s *boltdb) read(namespace, key string) ([]byte, error) {
+func (s *BoltDB) read(namespace, key string) ([]byte, error) {
 	var result []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(namespace))
@@ -134,7 +134,7 @@ func (s *boltdb) read(namespace, key string) ([]byte, error) {
 	return result, err
 }
 
-func (s *boltdb) readAll(namespace string) (map[string][]byte, error) {
+func (s *BoltDB) readAll(namespace string) (map[string][]byte, error) {
 	result := make(map[string][]byte)
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(namespace))
@@ -151,7 +151,7 @@ func (s *boltdb) readAll(namespace string) (map[string][]byte, error) {
 	return result, err
 }
 
-func (s *boltdb) readSeveral(namespace string, after []byte, count int) ([]boltRecord, error) {
+func (s *BoltDB) readSeveral(namespace string, after []byte, count int) ([]boltRecord, error) {
 	var result []boltRecord
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(namespace))

--- a/impl/pkg/storage/db/bolt/bolt_test.go
+++ b/impl/pkg/storage/db/bolt/bolt_test.go
@@ -194,3 +194,13 @@ func TestDBPagination(t *testing.T) {
 	assert.Nil(t, nextPageToken)
 	assert.Len(t, page, 1+len(preTestRecords))
 }
+
+func TestNewBolt(t *testing.T) {
+	b, err := NewBolt("")
+	assert.Error(t, err)
+	assert.Nil(t, b)
+
+	b, err = NewBolt("bolt:///fake/path/bolt.db")
+	assert.Error(t, err)
+	assert.Nil(t, b)
+}

--- a/impl/pkg/storage/db/postgres/postgres.go
+++ b/impl/pkg/storage/db/postgres/postgres.go
@@ -97,32 +97,6 @@ func (p postgres) ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, err
 	return record, nil
 }
 
-func (p postgres) ListAllRecords(ctx context.Context) ([]pkarr.Record, error) {
-	queries, db, err := p.connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close(ctx)
-
-	rows, err := queries.ListAllRecords(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var records []pkarr.Record
-	for _, row := range rows {
-		record, err := row.Record()
-		if err != nil {
-			// TODO: do something useful if this happens
-			logrus.WithError(err).WithField("record_id", row.ID).Warn("error loading record from database, skipping")
-			continue
-		}
-		records = append(records, *record)
-	}
-
-	return records, nil
-}
-
 func (p postgres) ListRecords(ctx context.Context, nextPageToken []byte, limit int) ([]pkarr.Record, []byte, error) {
 	queries, db, err := p.connect(ctx)
 	if err != nil {

--- a/impl/pkg/storage/db/postgres/postgres.go
+++ b/impl/pkg/storage/db/postgres/postgres.go
@@ -89,7 +89,7 @@ func (p Postgres) ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, err
 		return nil, err
 	}
 
-	record, err := pkarr.NewRecord(row.Key, row.Value, row.Sig, row.Seq)
+	record, err := row.Record()
 	if err != nil {
 		return nil, err
 	}

--- a/impl/pkg/storage/db/postgres/postgres.go
+++ b/impl/pkg/storage/db/postgres/postgres.go
@@ -17,11 +17,11 @@ import (
 //go:embed migrations
 var migrations embed.FS
 
-type postgres string
+type Postgres string
 
 // NewPostgres creates a PostgresQL-based implementation of storage.Storage
-func NewPostgres(uri string) (postgres, error) {
-	db := postgres(uri)
+func NewPostgres(uri string) (Postgres, error) {
+	db := Postgres(uri)
 	if err := db.migrate(); err != nil {
 		return db, fmt.Errorf("error migrating postgres database: %v", err)
 	}
@@ -29,7 +29,7 @@ func NewPostgres(uri string) (postgres, error) {
 	return db, nil
 }
 
-func (p postgres) migrate() error {
+func (p Postgres) migrate() error {
 	db, err := sql.Open("pgx/v5", string(p))
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (p postgres) migrate() error {
 	return nil
 }
 
-func (p postgres) connect(ctx context.Context) (*Queries, *pgx.Conn, error) {
+func (p Postgres) connect(ctx context.Context) (*Queries, *pgx.Conn, error) {
 	conn, err := pgx.Connect(ctx, string(p))
 	if err != nil {
 		return nil, nil, err
@@ -57,7 +57,7 @@ func (p postgres) connect(ctx context.Context) (*Queries, *pgx.Conn, error) {
 	return New(conn), conn, nil
 }
 
-func (p postgres) WriteRecord(ctx context.Context, record pkarr.Record) error {
+func (p Postgres) WriteRecord(ctx context.Context, record pkarr.Record) error {
 	queries, db, err := p.connect(ctx)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (p postgres) WriteRecord(ctx context.Context, record pkarr.Record) error {
 	return nil
 }
 
-func (p postgres) ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, error) {
+func (p Postgres) ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, error) {
 	queries, db, err := p.connect(ctx)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (p postgres) ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, err
 	return record, nil
 }
 
-func (p postgres) ListRecords(ctx context.Context, nextPageToken []byte, limit int) ([]pkarr.Record, []byte, error) {
+func (p Postgres) ListRecords(ctx context.Context, nextPageToken []byte, limit int) ([]pkarr.Record, []byte, error) {
 	queries, db, err := p.connect(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -138,7 +138,7 @@ func (p postgres) ListRecords(ctx context.Context, nextPageToken []byte, limit i
 	return records, nextPageToken, nil
 }
 
-func (p postgres) Close() error {
+func (p Postgres) Close() error {
 	// no-op, postgres connection is closed after each request
 	return nil
 }

--- a/impl/pkg/storage/db/postgres/postgres_test.go
+++ b/impl/pkg/storage/db/postgres/postgres_test.go
@@ -1,104 +1,36 @@
-package bolt
+package postgres_test
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/TBD54566975/did-dht-method/internal/did"
 	"github.com/TBD54566975/did-dht-method/pkg/dht"
 	"github.com/TBD54566975/did-dht-method/pkg/pkarr"
-	"github.com/goccy/go-json"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/TBD54566975/did-dht-method/pkg/storage"
+	"github.com/TBD54566975/did-dht-method/pkg/storage/db/postgres"
 )
 
-func TestBoltDB_ReadWrite(t *testing.T) {
-	db := getTestDB(t)
+func getTestDB(t *testing.T) storage.Storage {
+	uri := os.Getenv("TEST_DB")
+	if uri == "" {
+		t.SkipNow()
+	}
 
-	// create a name space and a message in it
-	namespace := "F1"
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	if u.Scheme != "postgres" {
+		t.SkipNow()
+	}
 
-	team1 := "Red Bull"
-	players1 := []string{"Max Verstappen", "Sergio Pérez"}
-	p1Bytes, err := json.Marshal(players1)
-	assert.NoError(t, err)
+	db, err := postgres.NewPostgres(uri)
+	require.NoError(t, err)
 
-	err = db.write(namespace, team1, p1Bytes)
-	assert.NoError(t, err)
-
-	// get it back
-	gotPlayers1, err := db.read(namespace, team1)
-	assert.NoError(t, err)
-
-	var players1Result []string
-	err = json.Unmarshal(gotPlayers1, &players1Result)
-	assert.NoError(t, err)
-	assert.EqualValues(t, players1, players1Result)
-
-	// get a value from a dhtNamespace that doesn't exist
-	res, err := db.read("bad", "worse")
-	assert.NoError(t, err)
-	assert.Empty(t, res)
-
-	// get a value that doesn't exist in the dhtNamespace
-	noValue, err := db.read(namespace, "Porsche")
-	assert.NoError(t, err)
-	assert.Empty(t, noValue)
-
-	// create a second value in the dhtNamespace
-	team2 := "McLaren"
-	players2 := []string{"Lando Norris", "Daniel Ricciardo"}
-	p2Bytes, err := json.Marshal(players2)
-	assert.NoError(t, err)
-
-	err = db.write(namespace, team2, p2Bytes)
-	assert.NoError(t, err)
-
-	// get all values from the dhtNamespace
-	gotAll, err := db.readAll(namespace)
-	assert.NoError(t, err)
-	assert.True(t, len(gotAll) == 2)
-
-	_, gotRedBull := gotAll[team1]
-	assert.True(t, gotRedBull)
-
-	_, gotMcLaren := gotAll[team2]
-	assert.True(t, gotMcLaren)
-}
-
-func TestBoltDB_PrefixAndKeys(t *testing.T) {
-	db := getTestDB(t)
-
-	namespace := "blockchains"
-
-	// set up prefix read test
-
-	dummyData := []byte("dummy")
-	err := db.write(namespace, "bitcoin-testnet", dummyData)
-	assert.NoError(t, err)
-
-	err = db.write(namespace, "bitcoin-mainnet", dummyData)
-	assert.NoError(t, err)
-
-	err = db.write(namespace, "tezos-testnet", dummyData)
-	assert.NoError(t, err)
-
-	err = db.write(namespace, "tezos-mainnet", dummyData)
-	assert.NoError(t, err)
-}
-
-func getTestDB(t *testing.T) *BoltDB {
-	path := "test.db"
-	db, err := NewBolt(path)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, db)
-
-	t.Cleanup(func() {
-		_ = db.Close()
-		_ = os.Remove(path)
-	})
 	return db
 }
 

--- a/impl/pkg/storage/db/postgres/queries.sql.go
+++ b/impl/pkg/storage/db/postgres/queries.sql.go
@@ -9,38 +9,8 @@ import (
 	"context"
 )
 
-const listAllRecords = `-- name: ListAllRecords :many
-SELECT id, key, value, sig, seq FROM pkarr_records
-`
-
-func (q *Queries) ListAllRecords(ctx context.Context) ([]PkarrRecord, error) {
-	rows, err := q.db.Query(ctx, listAllRecords)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []PkarrRecord
-	for rows.Next() {
-		var i PkarrRecord
-		if err := rows.Scan(
-			&i.ID,
-			&i.Key,
-			&i.Value,
-			&i.Sig,
-			&i.Seq,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listRecords = `-- name: ListRecords :many
-SELECT id, key, value, sig, seq FROM pkarr_records WHERE id > (SELECT id FROM pkarr_records WHERE pkarr_records.key = $1) ORDER BY ID ASC LIMIT $2
+SELECT id, key, value, sig, seq FROM pkarr_records WHERE id > (SELECT id FROM pkarr_records WHERE pkarr_records.key = $1) ORDER BY id ASC LIMIT $2
 `
 
 type ListRecordsParams struct {

--- a/impl/pkg/storage/db/postgres/queries/queries.sql
+++ b/impl/pkg/storage/db/postgres/queries/queries.sql
@@ -4,9 +4,6 @@ INSERT INTO pkarr_records(key, value, sig, seq) VALUES($1, $2, $3, $4);
 -- name: ReadRecord :one
 SELECT * FROM pkarr_records WHERE key = $1 LIMIT 1;
 
--- name: ListAllRecords :many
-SELECT * FROM pkarr_records;
-
 -- name: ListRecords :many
 SELECT * FROM pkarr_records WHERE id > (SELECT id FROM pkarr_records WHERE pkarr_records.key = $1) ORDER BY id ASC LIMIT $2;
 

--- a/impl/pkg/storage/storage.go
+++ b/impl/pkg/storage/storage.go
@@ -17,7 +17,6 @@ type Storage interface {
 	WriteRecord(ctx context.Context, record pkarr.Record) error
 	ReadRecord(ctx context.Context, id []byte) (*pkarr.Record, error)
 	ListRecords(ctx context.Context, nextPageToken []byte, pagesize int) (records []pkarr.Record, nextPage []byte, err error)
-	ListAllRecords(ctx context.Context) ([]pkarr.Record, error)
 	Close() error
 }
 

--- a/impl/pkg/storage/storage_test.go
+++ b/impl/pkg/storage/storage_test.go
@@ -1,128 +1,43 @@
 package storage_test
 
 import (
-	"context"
-	"fmt"
-	"math/rand"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/TBD54566975/did-dht-method/internal/did"
-	"github.com/TBD54566975/did-dht-method/pkg/dht"
-	"github.com/TBD54566975/did-dht-method/pkg/pkarr"
 	"github.com/TBD54566975/did-dht-method/pkg/storage"
+	"github.com/TBD54566975/did-dht-method/pkg/storage/db/bolt"
+	"github.com/TBD54566975/did-dht-method/pkg/storage/db/postgres"
 )
 
-func getTestDB(t *testing.T) storage.Storage {
+func TestNewStoragePostgres(t *testing.T) {
 	uri := os.Getenv("TEST_DB")
 	if uri == "" {
-		uri = fmt.Sprintf("bolt://test-%d.db", rand.Int())
+		t.SkipNow()
+	}
+
+	u, err := url.Parse(uri)
+	require.NoError(t, err)
+	if u.Scheme != "postgres" {
+		t.SkipNow()
 	}
 
 	db, err := storage.NewStorage(uri)
 	require.NoError(t, err)
-	require.NotEmpty(t, db)
-
-	return db
-}
-func TestPKARRStorage(t *testing.T) {
-	db := getTestDB(t)
-	defer db.Close()
-
-	// create a did doc as a packet to store
-	sk, doc, err := did.GenerateDIDDHT(did.CreateDIDDHTOpts{})
-	require.NoError(t, err)
-	require.NotEmpty(t, doc)
-
-	packet, err := did.DHT(doc.ID).ToDNSPacket(*doc, nil)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, packet)
-
-	putMsg, err := dht.CreatePKARRPublishRequest(sk, *packet)
-	require.NoError(t, err)
-	require.NotEmpty(t, putMsg)
-
-	// create record
-	record := pkarr.RecordFromBEP44(putMsg)
-
-	ctx := context.Background()
-
-	err = db.WriteRecord(ctx, record)
-	assert.NoError(t, err)
-
-	// read it back
-	readRecord, err := db.ReadRecord(ctx, record.Key[:])
-	assert.NoError(t, err)
-	assert.Equal(t, record, *readRecord)
-
-	// list and confirm it's there
-	records, _, err := db.ListRecords(ctx, nil, 10)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, records)
-	assert.Equal(t, record, records[0])
+	assert.IsType(t, postgres.Postgres(""), db)
 }
 
-func TestDBPagination(t *testing.T) {
-	db := getTestDB(t)
-	defer db.Close()
-
-	ctx := context.Background()
-
-	preTestRecords, _, err := db.ListRecords(ctx, nil, 10)
-	assert.NoError(t, err)
-
-	// store 10 records
-	for i := 0; i < 10; i++ {
-		// create a did doc as a packet to store
-		sk, doc, err := did.GenerateDIDDHT(did.CreateDIDDHTOpts{})
-		require.NoError(t, err)
-		require.NotEmpty(t, doc)
-
-		packet, err := did.DHT(doc.ID).ToDNSPacket(*doc, nil)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, packet)
-
-		putMsg, err := dht.CreatePKARRPublishRequest(sk, *packet)
-		require.NoError(t, err)
-		require.NotEmpty(t, putMsg)
-
-		// create record
-		record := pkarr.RecordFromBEP44(putMsg)
-
-		err = db.WriteRecord(ctx, record)
-		assert.NoError(t, err)
-	}
-
-	// store 11th document
-	// create a did doc as a packet to store
-	sk, doc, err := did.GenerateDIDDHT(did.CreateDIDDHTOpts{})
+func TestNewStorageBolt(t *testing.T) {
+	db, err := storage.NewStorage("bolt:///tmp/bolt.db")
 	require.NoError(t, err)
-	require.NotEmpty(t, doc)
+	assert.IsType(t, &bolt.BoltDB{}, db)
+}
 
-	packet, err := did.DHT(doc.ID).ToDNSPacket(*doc, nil)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, packet)
-
-	putMsg, err := dht.CreatePKARRPublishRequest(sk, *packet)
-	require.NoError(t, err)
-	require.NotEmpty(t, putMsg)
-
-	// create eleventhRecord
-	eleventhRecord := pkarr.RecordFromBEP44(putMsg)
-
-	err = db.WriteRecord(ctx, eleventhRecord)
-	assert.NoError(t, err)
-
-	// read the first 10 back
-	page, nextPageToken, err := db.ListRecords(ctx, nil, 10)
-	assert.NoError(t, err)
-	assert.Len(t, page, 10)
-
-	page, nextPageToken, err = db.ListRecords(ctx, nextPageToken, 10+len(preTestRecords))
-	assert.NoError(t, err)
-	assert.Nil(t, nextPageToken)
-	assert.Len(t, page, 1+len(preTestRecords))
+func TestNewStorageUnsupported(t *testing.T) {
+	db, err := storage.NewStorage("imaginaryDB://a:b@c/d")
+	require.Error(t, err)
+	assert.Nil(t, db)
 }


### PR DESCRIPTION
This PR attempts to address two issues:
* #22 - the DHT library we use binds it's server to `localhost:0` for it's tests ([here](https://github.com/anacrolix/dht/blob/master/server_test.go#L97-L101)), which seems to keep the tests off the public network. I've moved all of our tests to use this setup.
* #15 - calls for 80% test coverage. As I'm writing this, the PR brings it from 57.14% to 73%.
  * it also calls for postgres testing. This PR reworks the storage-related tests so that both bolt and postgres have roughly identical test suites (bolt had some other tests that I left in place).
  * it also calls for integration testing, but most of this is unit testing currently.