### PR TITLE
use logrus for logging from the DHT library

### DIFF
--- a/impl/config/config.go
+++ b/impl/config/config.go
@@ -50,7 +50,6 @@ type ServerConfig struct {
 	APIHost     string      `toml:"api_host"`
 	APIPort     int         `toml:"api_port"`
 	BaseURL     string      `toml:"base_url"`
-	LogLocation string      `toml:"log_location"`
 	StorageURI  string      `toml:"storage_uri"`
 }
 
@@ -76,7 +75,6 @@ func GetDefaultConfig() Config {
 			APIHost:     "0.0.0.0",
 			APIPort:     8305,
 			BaseURL:     "http://localhost:8305",
-			LogLocation: "log",
 			StorageURI:  "bolt://diddht.db",
 		},
 		DHTConfig: DHTServiceConfig{
@@ -160,6 +158,16 @@ func applyEnvVariables(cfg *Config) error {
 	storage, present := os.LookupEnv("STORAGE_URI")
 	if present {
 		cfg.ServerConfig.StorageURI = storage
+	}
+
+	levelString, present := os.LookupEnv("LOG_LEVEL")
+	if present {
+		_, err := logrus.ParseLevel(levelString)
+		if err != nil {
+			logrus.WithField("requested_level", levelString).Warn("unable to parse log level requested in environment variable")
+		} else {
+			cfg.Log.Level = levelString
+		}
 	}
 
 	return nil

--- a/impl/pkg/service/pkarr.go
+++ b/impl/pkg/service/pkarr.go
@@ -99,7 +99,7 @@ func (s *PkarrService) PublishPkarr(ctx context.Context, id string, record pkarr
 
 // GetPkarr returns the full Pkarr record (including sig data) for the given z-base-32 encoded ID
 func (s *PkarrService) GetPkarr(ctx context.Context, id string) (*pkarr.Response, error) {
-	ctx, span := telemetry.GetTracer().Start(ctx, "PkarrService,GetPkarr")
+	ctx, span := telemetry.GetTracer().Start(ctx, "PkarrService.GetPkarr")
 	defer span.End()
 
 	// first do a cache lookup


### PR DESCRIPTION
fixes #137:

```json
{
    "file": "/app/pkg/dht/dht.go:138",
    "func": "github.com/TBD54566975/did-dht-method/pkg/dht.loghandler.Handle",
    "level": "debug",
    "msg": "received query \"get_peers\" from xxx.xxx.xxx.xxx:6881",
    "names": [
        "github.com/anacrolix/dht/v2",
        "server.go:317"
    ],
    "time": "2024-03-11T23:13:11Z"
}
{
    "file": "/app/pkg/dht/dht.go:138",
    "func": "github.com/TBD54566975/did-dht-method/pkg/dht.loghandler.Handle",
    "level": "debug",
    "msg": "replying to \"xxx.xxx.xxx.xxx:6881\"",
    "names": [
        "github.com/anacrolix/dht/v2",
        "server.go:685"
    ],
    "time": "2024-03-11T23:13:11Z"
}
{
    "file": "/app/pkg/dht/dht.go:138",
    "func": "github.com/TBD54566975/did-dht-method/pkg/dht.loghandler.Handle",
    "level": "debug",
    "msg": "received query \"find_node\" from xxx.xxx.xxx.xxx:53525",
    "names": [
        "github.com/anacrolix/dht/v2",
        "server.go:317"
    ],
    "time": "2024-03-11T23:13:14Z"
}
{
    "file": "/app/pkg/dht/dht.go:138",
    "func": "github.com/TBD54566975/did-dht-method/pkg/dht.loghandler.Handle",
    "level": "debug",
    "msg": "replying to \"xxx.xxx.xxx.xxx:53525\"",
    "names": [
        "github.com/anacrolix/dht/v2",
        "server.go:685"
    ],
    "time": "2024-03-11T23:13:14Z"
}
```

other misc changes while I was working on this:
* add an environment variable to override the log level (for easier testing in a local container)
* remove hard-coded URL from integration test
* fix PkarrServer span name typo