### PR TITLE
update to eddsa

### DIFF
--- a/impl/internal/did/did.go
+++ b/impl/internal/did/did.go
@@ -233,8 +233,7 @@ func CreateDIDDHTDID(pubKey ed25519.PublicKey, opts CreateDIDDHTOpts) (*did.Docu
 	// create the did document
 	kid := "0"
 	key0JWK, err := jwx.PublicKeyToPublicKeyJWK(&kid, pubKey)
-	// temporary workaround until https://github.com/TBD54566975/ssi-sdk/issues/520 is in place
-	key0JWK.ALG = string(crypto.Ed25519DSA)
+	key0JWK.ALG = string(crypto.EdDSA)
 	if err != nil {
 		return nil, err
 	}
@@ -843,9 +842,9 @@ func parseTxtData(data string) map[string]string {
 // algIsDefaultForJWK returns true if the given JWK ALG is the default for the given key type
 // according to the key type index https://did-dht.com/registry/#key-type-index
 func algIsDefaultForJWK(jwk jwx.PublicKeyJWK) bool {
-	// Ed25519 : Ed25519
+	// Ed25519 : EdDSA
 	if jwk.CRV == crypto.Ed25519.String() && jwk.KTY == jwa.OKP.String() {
-		return jwk.ALG == string(crypto.Ed25519DSA)
+		return jwk.ALG == string(crypto.EdDSA)
 	}
 	// secp256k1 : ES256K
 	if jwk.CRV == crypto.SECP256k1.String() && jwk.KTY == jwa.EC.String() {
@@ -865,9 +864,9 @@ func algIsDefaultForJWK(jwk jwx.PublicKeyJWK) bool {
 // defaultAlgForJWK returns the default signature algorithm for the given JWK based on the key type index
 // https://did-dht.com/registry/#key-type-index
 func defaultAlgForJWK(jwk jwx.PublicKeyJWK) string {
-	// Ed25519 : Ed25519
+	// Ed25519 : EdDSA
 	if jwk.CRV == crypto.Ed25519.String() && jwk.KTY == jwa.OKP.String() {
-		return string(crypto.Ed25519DSA)
+		return string(crypto.EdDSA)
 	}
 	// secp256k1 : ES256K
 	if jwk.CRV == crypto.SECP256k1.String() && jwk.KTY == jwa.EC.String() {
@@ -904,7 +903,7 @@ func keyTypeLookUp(keyType string) crypto.KeyType {
 // keyTypeForJWK returns the key type index for the given JWK according to the key type index
 // https://did-dht.com/registry/#key-type-index
 func keyTypeForJWK(jwk jwx.PublicKeyJWK) int {
-	// Ed25519 : Ed25519 : 0
+	// Ed25519 : EdDSA : 0
 	if jwk.CRV == crypto.Ed25519.String() && jwk.KTY == jwa.OKP.String() {
 		return 0
 	}

--- a/impl/internal/did/did.go
+++ b/impl/internal/did/did.go
@@ -233,6 +233,7 @@ func CreateDIDDHTDID(pubKey ed25519.PublicKey, opts CreateDIDDHTOpts) (*did.Docu
 	// create the did document
 	kid := "0"
 	key0JWK, err := jwx.PublicKeyToPublicKeyJWK(&kid, pubKey)
+	//nolint:staticcheck
 	key0JWK.ALG = string(crypto.EdDSA)
 	if err != nil {
 		return nil, err
@@ -844,6 +845,7 @@ func parseTxtData(data string) map[string]string {
 func algIsDefaultForJWK(jwk jwx.PublicKeyJWK) bool {
 	// Ed25519 : EdDSA
 	if jwk.CRV == crypto.Ed25519.String() && jwk.KTY == jwa.OKP.String() {
+		//nolint:staticcheck
 		return jwk.ALG == string(crypto.EdDSA)
 	}
 	// secp256k1 : ES256K
@@ -866,6 +868,7 @@ func algIsDefaultForJWK(jwk jwx.PublicKeyJWK) bool {
 func defaultAlgForJWK(jwk jwx.PublicKeyJWK) string {
 	// Ed25519 : EdDSA
 	if jwk.CRV == crypto.Ed25519.String() && jwk.KTY == jwa.OKP.String() {
+		//nolint:staticcheck
 		return string(crypto.EdDSA)
 	}
 	// secp256k1 : ES256K

--- a/impl/internal/did/testdata/vector-1-did-document.json
+++ b/impl/internal/did/testdata/vector-1-did-document.json
@@ -9,7 +9,7 @@
         "kty": "OKP",
         "crv": "Ed25519",
         "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "kid": "0"
       }
     }

--- a/impl/internal/did/testdata/vector-1-public-key-jwk-1.json
+++ b/impl/internal/did/testdata/vector-1-public-key-jwk-1.json
@@ -2,6 +2,6 @@
   "kty": "OKP",
   "crv": "Ed25519",
   "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE",
-  "alg": "Ed25519",
+  "alg": "EdDSA",
   "kid": "0"
 }

--- a/impl/internal/did/testdata/vector-2-did-document.json
+++ b/impl/internal/did/testdata/vector-2-did-document.json
@@ -11,7 +11,7 @@
         "kty": "OKP",
         "crv": "Ed25519",
         "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "kid": "0"
       }
     },

--- a/impl/internal/did/testdata/vector-3-did-document.json
+++ b/impl/internal/did/testdata/vector-3-did-document.json
@@ -7,7 +7,7 @@
       "controller": "did:dht:sr6jgmcc84xig18ix66qbiwnzeiumocaaybh13f5w97bfzus4pcy",
       "publicKeyJwk": {
         "kid": "0",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "crv": "Ed25519",
         "kty": "OKP",
         "x": "sTyTLYw-n1NI9X-84NaCuis1wZjAA8lku6f6Et5201g"

--- a/impl/internal/did/testdata/vector-3-public-key-jwk-1.json
+++ b/impl/internal/did/testdata/vector-3-public-key-jwk-1.json
@@ -2,6 +2,6 @@
   "kty": "OKP",
   "crv": "Ed25519",
   "x": "sTyTLYw-n1NI9X-84NaCuis1wZjAA8lku6f6Et5201g",
-  "alg": "Ed25519",
+  "alg": "EdDSA",
   "kid": "0"
 }

--- a/spec/registry/spec.md
+++ b/spec/registry/spec.md
@@ -9,7 +9,7 @@ The DID DHT Method Specification Registry 1.0
 
 **Draft Created:** November 20, 2023
 
-**Latest Update:** May 14, 2024
+**Latest Update:** May 31, 2024
 
 **Editors:**
 ~ [Gabe Cohen](https://github.com/decentralgabe)
@@ -39,7 +39,7 @@ For each key type a default algorithm is provided to be used with the key's `JWK
 
 | Index | Key Type                                               | Default Algorithm |
 | ----- | ------------------------------------------------------ | ----------------- |
-| 0     | [Ed25519](https://ed25519.cr.yp.to/)                   | [Ed25519](https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/) [[ref:Fully-Specified Algorithms for JOSE and COSE]] |
+| 0     | [Ed25519](https://ed25519.cr.yp.to/)                   | [EdDSA](https://datatracker.ietf.org/doc/html/rfc8032#section-3) [[spec:RFC8302]] |
 | 1     | [secp256k1](https://datatracker.ietf.org/doc/html/rfc8812#section-3.1) | [ES256K](https://www.rfc-editor.org/rfc/rfc8812.html) [[spec:RFC8812]] |
 | 2     | [secp256r1](https://neuromancer.sk/std/secg/secp256r1) / [P-256](https://neuromancer.sk/std/nist/P-256) | [ES256](https://www.rfc-editor.org/rfc/rfc7518.html) [[spec:RFC7518]] |
 | 3     | [X25519](https://www.rfc-editor.org/rfc/rfc7748) [[spec:RFC7748]] | [ECDH-ES+A256KW](https://datatracker.ietf.org/doc/html/rfc7518#section-4.6) [[spec:RFC7518]] |
@@ -217,9 +217,5 @@ JWK into a DID Document. J. Miller.
 [[def:z-base-32]]
 ~ [z-base-32](https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt). Human-oriented base-32 encoding.
 Z. O'Whielacronx; November 2002.
-
-[[def:Fully-Specified Algorithms for JOSE and COSE]]
-~ [Fully-Specified Algorithms for JOSE and COSE](https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/).
-M. Jones, O. Steele; 28 February 2024. [Internet Engineering Task Force](https://ietf.org).
 
 [[spec]]

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -9,7 +9,7 @@ The DID DHT Method Specification 1.0
 
 **Draft Created**: October 20, 2023
 
-**Last Updated**: May 22, 2024
+**Last Updated**: May 31, 2024
 
 **Editors**:
 ~ [Gabe Cohen](https://github.com/decentralgabe)
@@ -441,7 +441,7 @@ A sample transformation of a fully-featured DID Document to a DNS packet is exem
       "controller": "did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y",
       "publicKeyJwk": {
         "kid": "0",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "crv": "Ed25519",
         "kty": "OKP",
         "x": "r96mnGNgWGOmjt6g_3_0nd4Kls5-kknrd4DdPW8qtfw"
@@ -1015,7 +1015,7 @@ Requests without a `retention_solution` have **no retention guarantees**.
         "controller": "did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y",
         "publicKeyJwk": {
           "kid": "0",
-          "alg": "Ed25519",
+          "alg": "EdDSA",
           "crv": "Ed25519",
           "kty": "OKP",
           "x": "r96mnGNgWGOmjt6g_3_0nd4Kls5-kknrd4DdPW8qtfw"
@@ -1345,7 +1345,7 @@ A minimal DID Document.
 ```json
 {
   "kid": "0",
-  "alg": "Ed25519",
+  "alg": "EdDSA",
   "crv": "Ed25519",
   "kty": "OKP",
   "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"
@@ -1364,7 +1364,7 @@ A minimal DID Document.
       "controller": "did:dht:cyuoqaf7itop8ohww4yn5ojg13qaq83r9zihgqntc5i9zwrfdfoo",
       "publicKeyJwk": {
         "kid": "0",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "crv": "Ed25519",
         "kty": "OKP",
         "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"
@@ -1403,7 +1403,7 @@ with multiple endpoints, a gateway, two types to index, an aka, and controller p
 ```json
 {
   "kid": "0",
-  "alg": "Ed25519",
+  "alg": "EdDSA",
   "crv": "Ed25519",
   "kty": "OKP",
   "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"
@@ -1455,7 +1455,7 @@ With controller: `did:dht:i9xkp8ddcbcg8jwq54ox699wuzxyifsqx4jru45zodqu453ksz6y` 
       "controller": "did:dht:cyuoqaf7itop8ohww4yn5ojg13qaq83r9zihgqntc5i9zwrfdfoo",
       "publicKeyJwk": {
         "kid": "0",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "crv": "Ed25519",
         "kty": "OKP",
         "x": "YCcHYL2sYNPDlKaALcEmll2HHyT968M4UWbr-9CFGWE"
@@ -1523,7 +1523,7 @@ what is specified in the registry. The DID also has two gateway records and a se
 ```json
 {
   "kid": "0",
-  "alg": "Ed25519",
+  "alg": "EdDSA",
   "crv": "Ed25519",
   "kty": "OKP",
   "x": "sTyTLYw-n1NI9X-84NaCuis1wZjAA8lku6f6Et5201g"
@@ -1572,7 +1572,7 @@ what is specified in the registry. The DID also has two gateway records and a se
       "controller": "did:dht:sr6jgmcc84xig18ix66qbiwnzeiumocaaybh13f5w97bfzus4pcy",
       "publicKeyJwk": {
         "kid": "0",
-        "alg": "Ed25519",
+        "alg": "EdDSA",
         "crv": "Ed25519",
         "kty": "OKP",
         "x": "sTyTLYw-n1NI9X-84NaCuis1wZjAA8lku6f6Et5201g"


### PR DESCRIPTION
move the default alg to eddsa for simplicity since ed25519 is not a standard yet and it will take a while for libs in the ecosystem to be updated