### PR TITLE
fix: bump otel semver

### DIFF
--- a/impl/pkg/telemetry/telemetry.go
+++ b/impl/pkg/telemetry/telemetry.go
@@ -13,7 +13,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/TBD54566975/did-dht/config"


### PR DESCRIPTION
Without this the service will not boot with telemetry enabled